### PR TITLE
Always return 1st jq result

### DIFF
--- a/sshrd.sh
+++ b/sshrd.sh
@@ -71,7 +71,7 @@ echo "[*] Getting device info... this may take a second"
 check=$("$oscheck"/irecovery -q | grep CPID | sed 's/CPID: //')
 replace=$("$oscheck"/irecovery -q | grep MODEL | sed 's/MODEL: //')
 deviceid=$("$oscheck"/irecovery -q | grep PRODUCT | sed 's/PRODUCT: //')
-ipswurl=$(curl -sL "https://api.ipsw.me/v4/device/$deviceid?type=ipsw" | "$oscheck"/jq '.firmwares | .[] | select(.version=="'$1'") | .url' --raw-output)
+ipswurl=$(curl -sL "https://api.ipsw.me/v4/device/$deviceid?type=ipsw" | "$oscheck"/jq '.firmwares | .[] | select(.version=="'$1'")' | "$oscheck"/jq -s '.[0] | .url' --raw-output)
 
 if [ -e work ]; then
     rm -rf work


### PR DESCRIPTION
Return the 1st result from the ipsw.me API with jq. This is useful in cases where there are 2 different ipsws for a version.