### PR TITLE
Bump up space

### DIFF
--- a/sshrd.sh
+++ b/sshrd.sh
@@ -221,7 +221,7 @@ else
 fi
 
 if [ "$oscheck" = 'Darwin' ]; then
-    hdiutil resize -size 190MB work/ramdisk.dmg
+    hdiutil resize -size 210MB work/ramdisk.dmg
     hdiutil attach -mountpoint /tmp/SSHRD work/ramdisk.dmg
 
     if [ "$replace" = 'j42dap' ]; then
@@ -236,7 +236,7 @@ if [ "$oscheck" = 'Darwin' ]; then
     hdiutil detach -force /tmp/SSHRD
     hdiutil resize -sectors min work/ramdisk.dmg
 else
-    "$oscheck"/hfsplus work/ramdisk.dmg grow 190000000 > /dev/null
+    "$oscheck"/hfsplus work/ramdisk.dmg grow 210000000 > /dev/null
 
     if [ "$replace" = 'j42dap' ]; then
         "$oscheck"/hfsplus work/ramdisk.dmg untar sshtars/atvssh.tar > /dev/null


### PR DESCRIPTION
Bumps up space just enough to build ramdisk. Tested with 14.3 and 15.6.

Based on previous commits, it seemed you wanted just enough for the ramdisk.

